### PR TITLE
Support for _TZ3000_7ysdnebc - #6

### DIFF
--- a/drivers/tuya-zigbee-dimmer-module.README.md
+++ b/drivers/tuya-zigbee-dimmer-module.README.md
@@ -7,7 +7,7 @@ Currently supported devices:
 | Model                     | What                             | Identifies via Zigbee as        |
 | :------------------------ | :------------------------------- | :------------------------------ |
 | QS-Zigbee-D02-TRIAC-LN    | 1 channel (1-gang) dimmer module | TS110F <br/> `_TYZB01_qezuin6k` |
-| QS-Zigbee-D02-TRIAC-2C-LN | 2 channel (2-gang) dimmer module | TS110F <br/> `_TYZB01_v8gtiaed` |
+| QS-Zigbee-D02-TRIAC-2C-LN | 2 channel (2-gang) dimmer module | TS110F <br/> `_TYZB01_v8gtiaed` <br/> TS1101 <br/> `_TZ3000_7ysdnebc` |
 | QS-Zigbee-D02-TRIAC-2C-L  | 2 channel (2-gang) dimmer module (no neutral) | TS110F <br/> `_TZ3000_92chsky7` |
 
 

--- a/drivers/tuya-zigbee-dimmer-module.groovy
+++ b/drivers/tuya-zigbee-dimmer-module.groovy
@@ -47,6 +47,10 @@ import groovy.transform.Field
         numEps: 2,
         joinName: "Tuya Zigbee 2-Gang Dimmer module"
     ],
+    "_TZ3000_7ysdnebc": [
+        numEps: 2,
+        joinName: "Tuya Zigbee 2-Gang Dimmer module"
+    ],
     "_TYZB01_qezuin6k": [
         numEps: 1,
         joinName: "Tuya Zigbee 1-Gang Dimmer module"

--- a/drivers/tuya-zigbee-dimmer-module.hpm-manifest.json
+++ b/drivers/tuya-zigbee-dimmer-module.hpm-manifest.json
@@ -1,12 +1,12 @@
 {
   "packageName": "Tuya zigbee dimmer modules",
   "author": "Matt Hammond",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "minimumHEVersion": "0.0",
   "licenseFile": "https://raw.githubusercontent.com/matt-hammond-001/hubitat-code/master/LICENSE",
   "documentationLink": "https://github.com/matt-hammond-001/hubitat-code/blob/master/drivers/tuya-zigbee-dimmer-module.README.md",
   "communityLink": "https://community.hubitat.com/t/release-tuya-1-gang-and-2-gang-dimmer-module-driver/60372",
-  "dateReleased": "2021-10-28",
+  "dateReleased": "2021-11-11",
   "drivers": [
     {
       "id": "decd3e44-bcc8-4321-8175-8db0c62450a1",
@@ -14,7 +14,7 @@
       "namespace": "matthammonddotorg",
       "location": "https://raw.githubusercontent.com/matt-hammond-001/hubitat-code/master/drivers/tuya-zigbee-dimmer-module.groovy",
       "required": true,
-      "version": "0.2.0"
+      "version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
Support for devices with manufacturer fingerprint:
* endpointId: 01
* application: 41
* softwareBuild:
* inClusters: 0000,0004,0005,0003,0006,0008
* outClusters: 0019,000A
* model: TS1101
* manufacturer: _TZ3000_7ysdnebc

https://community.hubitat.com/t/release-tuya-lonsonho-1-gang-and-2-gang-zigbee-dimmer-module-driver/60372/45?u=fc352bf0a6929e9fa80f
